### PR TITLE
Fix newline replacement

### DIFF
--- a/benchmarks/fail.js
+++ b/benchmarks/fail.js
@@ -61,7 +61,7 @@ function getLineAndColumn (offset) {
 function pastInput ({ offset }) {
   const start = Math.max(0, offset - 20)
   const previous = inputSource.substr(start, offset - start)
-  return (offset > 20 ? '...' : '') + previous.replace(/\n/g, '')
+  return (offset > 20 ? '...' : '') + previous.replace(/\r?\n/g, '')
 }
 
 function upcomingInput ({ offset }) {
@@ -69,7 +69,7 @@ function upcomingInput ({ offset }) {
   start += offset - start
   const rest = inputSource.length - start
   const next = inputSource.substr(start, Math.min(20, rest))
-  return next.replace(/\n/g, '') + (rest > 20 ? '...' : '')
+  return next.replace(/\r?\n/g, '') + (rest > 20 ? '...' : '')
 }
 
 function showPosition ({ offset }) {

--- a/src/native-parser.js
+++ b/src/native-parser.js
@@ -13,7 +13,7 @@ function getLineAndColumn (input, offset) {
 function pastInput (input, offset) {
   var start = Math.max(0, offset - 20)
   var previous = input.substr(start, offset - start)
-  return (offset > 20 ? '...' : '') + previous.replace(/\n/g, '')
+  return (offset > 20 ? '...' : '') + previous.replace(/\r?\n/g, '')
 }
 
 function upcomingInput (input, offset) {
@@ -21,7 +21,7 @@ function upcomingInput (input, offset) {
   start += offset - start
   var rest = input.length - start
   var next = input.substr(start, Math.min(20, rest))
-  return next.replace(/\n/g, '') + (rest > 20 ? '...' : '')
+  return next.replace(/\r?\n/g, '') + (rest > 20 ? '...' : '')
 }
 
 function getPositionContext (input, offset) {


### PR DESCRIPTION
Fix for Issue #1 

Changes error output newline replacement regex from
```/\n/g```
to 
```/\r?\n/g```

This accounts for different line endings (e.g. windows-style)