### PR TITLE
Include newline at end of files

### DIFF
--- a/lib/cli.js
+++ b/lib/cli.js
@@ -134,7 +134,7 @@ function processFile (file) {
   file = path.normalize(file)
   var source = parse(fs.readFileSync(file, 'utf8'), file)
   if (options.inPlace) {
-    fs.writeFileSync(file, source)
+    fs.writeFileSync(file, source + '\n')
   } else {
     if (!options.quiet) {
       console.log(source)


### PR DESCRIPTION
A new line at the end of files should probably be the default, I could make it configurable if not, but it seems like a sensible default to me.