### PR TITLE
Don't ignore duplicate keys with the following values: "", 0, false, null

### DIFF
--- a/src/custom-parser.js
+++ b/src/custom-parser.js
@@ -321,7 +321,7 @@ function parseInternal (input, options) {
     while (position < inputLength) {
       skipWhiteSpace()
       const key = parseKey()
-      if (allowDuplicateObjectKeys === false && result[key]) {
+      if (allowDuplicateObjectKeys === false && result.hasOwnProperty(key)) {
         fail('Duplicate key: "' + key + '"')
       }
       skipWhiteSpace()


### PR DESCRIPTION
Don't ignore duplicate keys with the following values: "", 0, false, null.
And don't throw errors on keys equal to keys in Object.prototype like "constructor".