### PR TITLE
docs: mention MegaLinter in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,8 @@ Integration to the favourite task loaders for JSON file validation is provided b
 * [`Gulp`] - see [`@prantlf/gulp-jsonlint`]
 * [`Rollup`] - see [`rollup-plugin-jsonlint`]
 
+For CI/CD pipelines, [MegaLinter](https://megalinter.io/) - an open-source linters aggregator - runs `jsonlint` on JSON files [out of the box](https://megalinter.io/latest/descriptors/json_jsonlint/).
+
 ## Synopsis
 
 Check syntax of JSON files:


### PR DESCRIPTION
Hi Ferdinand,

Small docs suggestion: MegaLinter (https://megalinter.io/), the open-source linters aggregator I maintain, ships your jsonlint fork as its default JSON linter, so users get it running in CI out of the box. I added a one-liner about it next to the Grunt/Gulp/Rollup integrations in the README, in case you find it useful for people looking to run jsonlint in their pipelines.

Feel free to reword or drop it if you'd rather keep the list as is. Thanks for maintaining this fork!